### PR TITLE
Fix SolarMetricsPanel props typing

### DIFF
--- a/src/components/SolarMetricsPanel.tsx
+++ b/src/components/SolarMetricsPanel.tsx
@@ -3,12 +3,12 @@ import { fetchSolarIrradiance } from '../services/nasaPowerService';
 import IrradianceGraph from './IrradianceGraph';
 import AstrophageWarningPanel from './AstrophageWarningPanel';
 
-interface Props {
+export interface SolarMetricsPanelProps {
   latitude: number;
   longitude: number;
 }
 
-const SolarMetricsPanel: React.FC<Props> = ({ latitude, longitude }) => {
+function SolarMetricsPanel({ latitude, longitude }: SolarMetricsPanelProps) {
   const [irradianceData, setIrradianceData] = useState<number[]>([]);
   const [dates, setDates] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- refactor SolarMetricsPanel to export explicit props interface
- use function component signature

## Testing
- `npm test --silent`
- `tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686d33fe8f4883299c32834f71b472a6