### PR TITLE
Hook Track button to refresh data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import SolarMetricsPanel from './components/SolarMetricsPanel';
 function App() {
   const [latitude, setLatitude] = useState(40);
   const [longitude, setLongitude] = useState(29);
+  const [refreshIndex, setRefreshIndex] = useState(0);
 
   return (
     <div className="App">
@@ -36,7 +37,7 @@ function App() {
           />
         </label>
         <button
-          onClick={() => {}}
+          onClick={() => setRefreshIndex((prev) => prev + 1)}
           style={{
             backgroundColor: '#00ffc3',
             border: 'none',
@@ -48,7 +49,11 @@ function App() {
         </button>
       </form>
 
-      <SolarMetricsPanel latitude={latitude} longitude={longitude} />
+      <SolarMetricsPanel
+        latitude={latitude}
+        longitude={longitude}
+        refreshTrigger={refreshIndex}
+      />
     </div>
   );
 }

--- a/src/components/SolarMetricsPanel.tsx
+++ b/src/components/SolarMetricsPanel.tsx
@@ -6,9 +6,14 @@ import AstrophageWarningPanel from './AstrophageWarningPanel';
 export interface SolarMetricsPanelProps {
   latitude: number;
   longitude: number;
+  refreshTrigger: number;
 }
 
-function SolarMetricsPanel({ latitude, longitude }: SolarMetricsPanelProps) {
+function SolarMetricsPanel({
+  latitude,
+  longitude,
+  refreshTrigger,
+}: SolarMetricsPanelProps) {
   const [irradianceData, setIrradianceData] = useState<number[]>([]);
   const [dates, setDates] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -40,7 +45,7 @@ function SolarMetricsPanel({ latitude, longitude }: SolarMetricsPanelProps) {
     };
 
     loadData();
-  }, [latitude, longitude]);
+  }, [latitude, longitude, refreshTrigger]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- add a refreshIndex state in `App` to track manual refresh
- trigger refresh when clicking the **Track** button
- refetch data in `SolarMetricsPanel` whenever `refreshTrigger` changes

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686d3d96d0748329ae8b7826abce006e