### PR TITLE
Fix date range logic and add test

### DIFF
--- a/src/components/SolarMetricsPanel.test.tsx
+++ b/src/components/SolarMetricsPanel.test.tsx
@@ -1,0 +1,36 @@
+import { render, waitFor } from '@testing-library/react';
+import SolarMetricsPanel from './SolarMetricsPanel';
+import * as nasaService from '../services/nasaPowerService';
+
+jest.mock('../services/nasaPowerService');
+
+const mockedFetch = nasaService.fetchSolarIrradiance as jest.MockedFunction<typeof nasaService.fetchSolarIrradiance>;
+
+describe('SolarMetricsPanel date range', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-02T00:00:00Z'));
+    mockedFetch.mockResolvedValue({
+      properties: { parameter: { ALLSKY_SFC_SW_DWN: {} } }
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  it('calls fetchSolarIrradiance with correct past week range', async () => {
+    render(<SolarMetricsPanel latitude={1} longitude={2} />);
+
+    await waitFor(() => {
+      expect(mockedFetch).toHaveBeenCalled();
+    });
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      1,
+      2,
+      '20231224',
+      '20231230'
+    );
+  });
+});

--- a/src/components/SolarMetricsPanel.tsx
+++ b/src/components/SolarMetricsPanel.tsx
@@ -17,8 +17,8 @@ function SolarMetricsPanel({ latitude, longitude }: SolarMetricsPanelProps) {
     const loadData = async () => {
       const today = new Date();
       today.setDate(today.getDate() - 3);
-      const pastWeek = new Date();
-      pastWeek.setDate(today.getDate() - 6);
+      const pastWeek = new Date(today);
+      pastWeek.setDate(pastWeek.getDate() - 6);
 
       const format = (date: Date) =>
         date.toISOString().split('T')[0].replace(/-/g, '');


### PR DESCRIPTION
## Summary
- adjust date range calculation for past week
- add unit test for date range logic

## Testing
- `CI=true npm test -- --runTestsByPath src/components/SolarMetricsPanel.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686d3d6a6f348329b52c4a7e98a4a357