### PR TITLE
Handle 0 previous values in warning panel

### DIFF
--- a/src/components/AstrophageWarningPanel.tsx
+++ b/src/components/AstrophageWarningPanel.tsx
@@ -10,6 +10,15 @@ const AstrophageWarningPanel: React.FC<Props> = ({ data, dates }) => {
 
   const latest = data[data.length - 1];
   const previous = data[data.length - 2];
+
+  if (previous === 0) {
+    return (
+      <div style={{ margin: '2rem auto', color: '#00ffc3', fontWeight: 'bold', fontSize: '1.25rem' }}>
+        <p>Previous value is zero — change cannot be computed.</p>
+      </div>
+    );
+  }
+
   const delta = latest - previous;
   const percentChange = (delta / previous) * 100;
 


### PR DESCRIPTION
## Summary
- guard against `previous` being 0 in `AstrophageWarningPanel`
- show a user friendly message when change can't be calculated

## Testing
- `npm test --silent -- -w 0`

------
https://chatgpt.com/codex/tasks/task_e_686d3d8b576c8329b9bae4e79c87b8f9