### PR TITLE
Configure NASA API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_NASA_API=https://power.larc.nasa.gov/api

--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ Inspired by *Project Hail Mary*, **Astrophage Tracker** visualizes solar irradia
 npm install
 ```
 
-3. Run the app:
+3. Copy `.env.example` to `.env` and adjust the `REACT_APP_NASA_API` value if you
+   need to point to a different NASA POWER API instance.
+
+4. Run the app:
 
 ```bash
 npm start
 ```
 
-4. Visit http://localhost:3000 in your browser.
-
-5. ---
+5. Visit http://localhost:3000 in your browser.
 
 ## 🔧 Development Notes
 - You can adjust latitude and longitude using the input fields.

--- a/src/services/nasaPowerService.ts
+++ b/src/services/nasaPowerService.ts
@@ -6,13 +6,16 @@ export interface SolarIrradianceResponse {
   };
 }
 
+const NASA_API_BASE =
+  process.env.REACT_APP_NASA_API || 'https://power.larc.nasa.gov/api';
+
 export async function fetchSolarIrradiance(
   latitude: number,
   longitude: number,
   startDate: string,
   endDate: string
 ): Promise<SolarIrradianceResponse> {
-  const url = `https://power.larc.nasa.gov/api/temporal/daily/point?parameters=ALLSKY_SFC_SW_DWN&start=${startDate}&end=${endDate}&latitude=${latitude}&longitude=${longitude}&community=RE&format=JSON`;
+  const url = `${NASA_API_BASE}/temporal/daily/point?parameters=ALLSKY_SFC_SW_DWN&start=${startDate}&end=${endDate}&latitude=${latitude}&longitude=${longitude}&community=RE&format=JSON`;
 
   const response = await fetch(url);
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- allow configuring NASA API base URL via `REACT_APP_NASA_API`
- document `.env` setup in README
- provide `.env.example`

## Testing
- `CI=true npm test -- --passWithNoTests --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d3da364fc8329bc5b8fefc541f10d