### PR TITLE
Add loading state for solar metrics

### DIFF
--- a/src/components/SolarMetricsPanel.tsx
+++ b/src/components/SolarMetricsPanel.tsx
@@ -12,9 +12,11 @@ function SolarMetricsPanel({ latitude, longitude }: SolarMetricsPanelProps) {
   const [irradianceData, setIrradianceData] = useState<number[]>([]);
   const [dates, setDates] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
     const loadData = async () => {
+      setLoading(true);
       const today = new Date();
       today.setDate(today.getDate() - 3);
       const pastWeek = new Date();
@@ -36,6 +38,8 @@ function SolarMetricsPanel({ latitude, longitude }: SolarMetricsPanelProps) {
         setIrradianceData(Object.values(irradianceMap));
       } catch (err) {
         setError('Could not load data.');
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -45,18 +49,24 @@ function SolarMetricsPanel({ latitude, longitude }: SolarMetricsPanelProps) {
   return (
     <div>
       <h2>Solar Irradiance (kWh/m²/day)</h2>
-      <AstrophageWarningPanel data={irradianceData} dates={dates} />
-      {error && <p>{error}</p>}
-      {!error && irradianceData.length > 0 && (
-        <ul>
-          {dates.map((date, idx) => (
-            <li key={date}>
-              <strong>{date}:</strong> {irradianceData[idx].toFixed(2)}
-            </li>
-          ))}
-        </ul>
+      {loading ? (
+        <p>Loading data...</p>
+      ) : (
+        <>
+          <AstrophageWarningPanel data={irradianceData} dates={dates} />
+          {error && <p>{error}</p>}
+          {!error && irradianceData.length > 0 && (
+            <ul>
+              {dates.map((date, idx) => (
+                <li key={date}>
+                  <strong>{date}:</strong> {irradianceData[idx].toFixed(2)}
+                </li>
+              ))}
+            </ul>
+          )}
+          <IrradianceGraph labels={dates} data={irradianceData} />
+        </>
       )}
-      <IrradianceGraph labels={dates} data={irradianceData} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a loading flag in `SolarMetricsPanel`
- show a simple loading message while fetching irradiance data

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d3d9ba8f4832995b9baa41a7dd57f