### PR TITLE
Fix SolarMetricsPanel tests

### DIFF
--- a/src/components/SolarMetricsPanel.test.tsx
+++ b/src/components/SolarMetricsPanel.test.tsx
@@ -2,6 +2,11 @@ import { render, waitFor } from '@testing-library/react';
 import SolarMetricsPanel from './SolarMetricsPanel';
 import * as nasaService from '../services/nasaPowerService';
 
+// Mock the chart component to avoid requiring a canvas implementation in JSDOM
+jest.mock('react-chartjs-2', () => ({
+  Line: () => <div data-testid="mock-line-chart" />,
+}));
+
 jest.mock('../services/nasaPowerService');
 
 const mockedFetch = nasaService.fetchSolarIrradiance as jest.MockedFunction<typeof nasaService.fetchSolarIrradiance>;
@@ -19,7 +24,7 @@ describe('SolarMetricsPanel date range', () => {
     jest.resetAllMocks();
   });
 
-  it('calls fetchSolarIrradiance with correct past week range', async () => {
+  it('calls fetchSolarIrradiance with correct three-month range', async () => {
     render(<SolarMetricsPanel latitude={1} longitude={2} refreshTrigger={0} />);
 
     await waitFor(() => {
@@ -29,7 +34,7 @@ describe('SolarMetricsPanel date range', () => {
     expect(mockedFetch).toHaveBeenCalledWith(
       1,
       2,
-      '20231224',
+      '20230930',
       '20231230'
     );
   });


### PR DESCRIPTION
## Summary
- update SolarMetricsPanel date range test to expect 3‑month range
- mock `react-chartjs-2` Line component in the test

## Testing
- `npx react-scripts test --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_686fa930d73c8329a9b93d384d593294