### PR TITLE
Add range checks for coordinates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,8 @@ function App() {
                 const parsed = parseFloat(value);
                 if (value === '' || isNaN(parsed)) {
                   setLatError('Please enter a valid number');
+                } else if (parsed < -90 || parsed > 90) {
+                  setLatError('Latitude must be between -90 and 90');
                 } else {
                   setLatError('');
                   setLatitude(parsed);
@@ -95,6 +97,8 @@ function App() {
                 const parsed = parseFloat(value);
                 if (value === '' || isNaN(parsed)) {
                   setLonError('Please enter a valid number');
+                } else if (parsed < -180 || parsed > 180) {
+                  setLonError('Longitude must be between -180 and 180');
                 } else {
                   setLonError('');
                   setLongitude(parsed);
@@ -108,11 +112,13 @@ function App() {
           </label>
           <button
             onClick={() => setRefreshIndex((prev) => prev + 1)}
+            disabled={latError !== '' || lonError !== ''}
             style={{
               backgroundColor: '#00ffc3',
               border: 'none',
               padding: '0.5rem 1rem',
-              cursor: 'pointer',
+              cursor: latError !== '' || lonError !== '' ? 'not-allowed' : 'pointer',
+              opacity: latError !== '' || lonError !== '' ? 0.5 : 1,
             }}
           >
             Track


### PR DESCRIPTION
## Summary
- validate latitude is between -90 and 90
- validate longitude is between -180 and 180
- disable the Track button when coordinates are invalid

## Testing
- `npm test --silent --watchAll=false` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa94a2c588329bd4a35255b211599