### PR TITLE
Add light mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Inspired by *Project Hail Mary*, **Astrophage Tracker** visualizes solar irradia
 - 🛑 Astrophage containment warnings based on energy drops
 - 🌍 Manual coordinate input for global tracking
 - 🧬 Fictional sci-fi overlay built on real scientific data
+- 🌗 Light/dark mode toggle for customized viewing
 
 ---
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,26 @@
+:root {
+  --bg-color: #0a0f1c;
+  --text-color: #00ffcc;
+  --accent-color: #00ffc3;
+  --accent-light: rgba(0, 255, 195, 0.05);
+  --scroll-thumb: #00ffc360;
+  --grid-color: rgba(0, 255, 195, 0.1);
+}
+
 body {
   margin: 0;
   font-family: 'Courier New', monospace;
-  background-color: #0a0f1c;
-  color: #00ffcc;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+body.light {
+  --bg-color: #f5f5f5;
+  --text-color: #003b3b;
+  --accent-color: #00ffc3;
+  --accent-light: rgba(0, 255, 195, 0.3);
+  --scroll-thumb: #00ffc360;
+  --grid-color: rgba(0, 255, 195, 0.3);
 }
 
 .App {
@@ -13,7 +31,7 @@ body {
 }
 
 h1, h2 {
-  color: #00ffc3;
+  color: var(--accent-color);
 }
 
 section {
@@ -43,7 +61,7 @@ li {
   max-width: 700px;
   margin-bottom: 2rem;
   padding: 1.5rem;
-  border: 1px solid #00ffc3;
+  border: 1px solid var(--accent-color);
   border-radius: 8px;
 }
 
@@ -51,7 +69,7 @@ li {
   width: 100%;
   max-width: 1000px;
   padding: 1.5rem;
-  border: 1px solid #00ffc3;
+  border: 1px solid var(--accent-color);
   border-radius: 8px;
 }
 
@@ -59,9 +77,9 @@ li {
   max-height: 300px;
   overflow-y: auto;
   padding: 0.5rem 1rem;         /* Reduced padding */
-  border: 1px solid #00ffc3;
+  border: 1px solid var(--accent-color);
   border-radius: 6px;           /* Slightly tighter border radius */
-  background-color: rgba(0, 255, 195, 0.05);
+  background-color: var(--accent-light);
   margin: 1rem auto;
   width: fit-content;           /* Prevents container from stretching */
 }
@@ -72,7 +90,7 @@ li {
   width: 6px;
 }
 .scroll-container::-webkit-scrollbar-thumb {
-  background-color: #00ffc360;
+  background-color: var(--scroll-thumb);
   border-radius: 3px;
 }
 .scroll-container::-webkit-scrollbar-track {
@@ -82,5 +100,5 @@ li {
 /* Hide scrollbar on Firefox */
 .scroll-container {
   scrollbar-width: thin;
-  scrollbar-color: #00ffc360 transparent;
+  scrollbar-color: var(--scroll-thumb) transparent;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './App.css';
 import SolarMetricsPanel from './components/SolarMetricsPanel';
 import { geocodeCity } from './services/geocodingService';
@@ -14,10 +14,28 @@ function App() {
   const [refreshIndex, setRefreshIndex] = useState(0);
   const [city, setCity] = useState('');
   const [cityError, setCityError] = useState('');
+  const [lightMode, setLightMode] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('light', lightMode);
+  }, [lightMode]);
 
   return (
     <div className="App">
       <h1>Astrophage Tracker</h1>
+      <button
+        className="theme-toggle"
+        onClick={() => setLightMode((prev) => !prev)}
+        style={{
+          backgroundColor: 'var(--accent-color)',
+          border: 'none',
+          padding: '0.3rem 0.8rem',
+          cursor: 'pointer',
+          marginBottom: '1rem',
+        }}
+      >
+        {lightMode ? 'Dark Mode' : 'Light Mode'}
+      </button>
 
       <section className="city-search-section">
         <form
@@ -49,7 +67,7 @@ function App() {
               }}
               style={{
                 marginLeft: '1rem',
-                backgroundColor: '#00ffc3',
+                backgroundColor: 'var(--accent-color)',
                 border: 'none',
                 padding: '0.3rem 0.8rem',
                 cursor: 'pointer',
@@ -114,7 +132,7 @@ function App() {
             onClick={() => setRefreshIndex((prev) => prev + 1)}
             disabled={latError !== '' || lonError !== ''}
             style={{
-              backgroundColor: '#00ffc3',
+              backgroundColor: 'var(--accent-color)',
               border: 'none',
               padding: '0.5rem 1rem',
               cursor: latError !== '' || lonError !== '' ? 'not-allowed' : 'pointer',
@@ -131,6 +149,7 @@ function App() {
           latitude={latitude}
           longitude={longitude}
           refreshTrigger={refreshIndex}
+          theme={lightMode ? 'light' : 'dark'}
         />
       </section>
     </div>

--- a/src/components/AstrophageWarningPanel.tsx
+++ b/src/components/AstrophageWarningPanel.tsx
@@ -13,7 +13,14 @@ const AstrophageWarningPanel: React.FC<Props> = ({ data, dates }) => {
 
   if (previous === 0) {
     return (
-      <div style={{ margin: '2rem auto', color: '#00ffc3', fontWeight: 'bold', fontSize: '1.25rem' }}>
+      <div
+        style={{
+          margin: '2rem auto',
+          color: 'var(--accent-color)',
+          fontWeight: 'bold',
+          fontSize: '1.25rem',
+        }}
+      >
         <p>Previous value is zero — change cannot be computed.</p>
       </div>
     );
@@ -23,7 +30,7 @@ const AstrophageWarningPanel: React.FC<Props> = ({ data, dates }) => {
   const percentChange = (delta / previous) * 100;
 
   let warning = 'Stable';
-  let color = '#00ffc3';
+  let color = 'var(--accent-color)';
 
   if (percentChange <= -2 && percentChange > -5) {
     warning = '⚠️ Minor Anomaly Detected';

--- a/src/components/IrradianceGraph.tsx
+++ b/src/components/IrradianceGraph.tsx
@@ -17,20 +17,26 @@ ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip,
 interface Props {
   labels: string[];
   data: number[];
+  theme: 'light' | 'dark';
 }
 
-const IrradianceGraph: React.FC<Props> = ({ labels, data }) => {
+const IrradianceGraph: React.FC<Props> = ({ labels, data, theme }) => {
+  const styles = getComputedStyle(document.body);
+  const accent = styles.getPropertyValue('--accent-color').trim();
+  const accentLight = styles.getPropertyValue('--accent-light').trim();
+  const gridColor = styles.getPropertyValue('--grid-color').trim();
+
   const chartData = {
     labels,
     datasets: [
       {
         label: 'Irradiance',
         data,
-        borderColor: '#00ffc3',
-        backgroundColor: 'rgba(0, 255, 195, 0.1)',
+        borderColor: accent,
+        backgroundColor: accentLight,
         tension: 0.3,
         pointRadius: 3,
-        pointBackgroundColor: '#00ffc3',
+        pointBackgroundColor: accent,
       },
     ],
   };
@@ -40,24 +46,24 @@ const IrradianceGraph: React.FC<Props> = ({ labels, data }) => {
     maintainAspectRatio: false,
     plugins: {
       legend: {
-        labels: { color: '#00ffc3' },
+        labels: { color: accent },
       },
     },
     scales: {
       x: {
-        ticks: { color: '#00ffc3' },
-        grid: { color: 'rgba(0,255,195,0.1)' },
+        ticks: { color: accent },
+        grid: { color: gridColor },
       },
       y: {
-        ticks: { color: '#00ffc3' },
-        grid: { color: 'rgba(0,255,195,0.1)' },
+        ticks: { color: accent },
+        grid: { color: gridColor },
       },
     },
   };
 
   return (
     <div style={{ width: '100%', maxWidth: '900px', height: '400px', margin: '0 auto' }}>
-      <Line data={chartData} options={options} />
+      <Line key={theme} data={chartData} options={options} />
     </div>
   );
 };

--- a/src/components/SolarMetricsPanel.test.tsx
+++ b/src/components/SolarMetricsPanel.test.tsx
@@ -25,7 +25,14 @@ describe('SolarMetricsPanel date range', () => {
   });
 
   it('calls fetchSolarIrradiance with correct three-month range', async () => {
-    render(<SolarMetricsPanel latitude={1} longitude={2} refreshTrigger={0} />);
+    render(
+      <SolarMetricsPanel
+        latitude={1}
+        longitude={2}
+        refreshTrigger={0}
+        theme="dark"
+      />
+    );
 
     await waitFor(() => {
       expect(mockedFetch).toHaveBeenCalled();

--- a/src/components/SolarMetricsPanel.tsx
+++ b/src/components/SolarMetricsPanel.tsx
@@ -7,12 +7,14 @@ export interface SolarMetricsPanelProps {
   latitude: number;
   longitude: number;
   refreshTrigger: number;
+  theme: 'light' | 'dark';
 }
 
 function SolarMetricsPanel({
   latitude,
   longitude,
   refreshTrigger,
+  theme,
 }: SolarMetricsPanelProps) {
   const [irradianceData, setIrradianceData] = useState<number[]>([]);
   const [dates, setDates] = useState<string[]>([]);
@@ -76,7 +78,7 @@ function SolarMetricsPanel({
             </ul>
             </div>
           )}
-          <IrradianceGraph labels={dates} data={irradianceData} />
+          <IrradianceGraph labels={dates} data={irradianceData} theme={theme} />
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add CSS variables and light theme styles
- implement theme toggle in App
- apply accent colors via CSS variables
- update SolarMetricsPanel and IrradianceGraph for theming
- tweak warning panel to respect accent color
- document light/dark toggle in README

## Testing
- `npm install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6870c5e833b883299c32fc27d3183686