### PR TITLE
Adjust warning to use weekly change

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Inspired by *Project Hail Mary*, **Astrophage Tracker** visualizes solar irradia
 
 - 🔭 Live solar irradiance data from NASA POWER API
 - 📉 Glowing graph panel to visualize daily energy levels
-- 🛑 Astrophage containment warnings based on energy drops
+- 🛑 Astrophage containment warnings based on week-over-week energy drops
 - 🌍 Manual coordinate input for global tracking
 - 🧬 Fictional sci-fi overlay built on real scientific data
 - 🌗 Light/dark mode toggle for customized viewing

--- a/src/components/AstrophageWarningPanel.tsx
+++ b/src/components/AstrophageWarningPanel.tsx
@@ -6,10 +6,11 @@ interface Props {
 }
 
 const AstrophageWarningPanel: React.FC<Props> = ({ data, dates }) => {
-  if (data.length < 2) return null;
+  // need at least a week's worth of data to calculate change
+  if (data.length < 8) return null;
 
   const latest = data[data.length - 1];
-  const previous = data[data.length - 2];
+  const previous = data[data.length - 8];
 
   if (previous === 0) {
     return (
@@ -47,7 +48,7 @@ const AstrophageWarningPanel: React.FC<Props> = ({ data, dates }) => {
     <div style={{ margin: '2rem auto', color, fontWeight: 'bold', fontSize: '1.25rem' }}>
       <p>{warning}</p>
       <p>
-        {dates[dates.length - 2]} → {dates[dates.length - 1]}:{' '}
+        {dates[dates.length - 8]} → {dates[dates.length - 1]}:{' '}
         {percentChange.toFixed(2)}% change in irradiance
       </p>
     </div>


### PR DESCRIPTION
## Summary
- update README to mention week-over-week warning logic
- compare irradiance over a week in AstrophageWarningPanel

## Testing
- `npm test -- -w 1`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870d07bacfc8329a9f153ffcdc74b7b