### PR TITLE
Fix theme toggle icon orientation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
       <h1>Astrophage Tracker</h1>
       <div style={{ marginBottom: '1rem' }}>
         <ThemeSwitch
-          checked={lightMode}
+          checked={!lightMode}
           onToggle={() => setLightMode((prev) => !prev)}
         />
       </div>

--- a/src/components/ThemeSwitch.css
+++ b/src/components/ThemeSwitch.css
@@ -1,7 +1,7 @@
 /* From Uiverse.io by Galahhad */
 
 .theme-switch {
-  --toggle-size: 30px;
+  --toggle-size: 24px;
   --container-width: 5.625em;
   --container-height: 2.5em;
   --container-radius: 6.25em;


### PR DESCRIPTION
## Summary
- fix ThemeSwitch to show moon in dark mode, sun in light mode
- shrink ThemeSwitch sizing

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6870feecc07c8329a6e12e3d3ec48b10